### PR TITLE
Merge dev Branch: Applying Changes for v0.2.0 Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ The reaction feature was introduced in Redmine 6.1 ([#42630](https://www.redmine
 - Skips notification when the reactor is the same person as the recipient (author or assignee).
 - Skips notification when the recipient's account is inactive or has no email address.
 - Respects the recipient's language setting for the notification email.
+- **Users can enable/disable reaction notifications** in their account preferences (My account > Preferences).
+  - By default, notifications are enabled.
+  - No database table modifications required; uses Redmine's built-in `UserPreference` model.
 
 ## Requirements
 

--- a/app/views/hooks/_my_account_preferences.html.erb
+++ b/app/views/hooks/_my_account_preferences.html.erb
@@ -1,0 +1,25 @@
+<p id="reaction_notification_pref_row">
+  <%= label_tag 'pref[reaction_notification]', l(:label_reaction_notification) %>
+  <%= hidden_field_tag 'pref[reaction_notification]', 0, id: nil %>
+  <%= check_box_tag 'pref[reaction_notification]', 1, user.pref.reaction_notification %>
+</p>
+
+<script>
+  // Move the reaction notification preference field into the mail notification fieldset
+  (function moveReactionNotificationPreference() {
+    var row = document.getElementById('reaction_notification_pref_row');
+    var mailSelect = document.getElementById('user_mail_notification');
+    if (!row || !mailSelect) {
+      return;
+    }
+
+    var mailFieldset = mailSelect.closest('fieldset');
+    if (!mailFieldset || row.parentElement === mailFieldset) {
+      return;
+    }
+
+    mailFieldset.appendChild(row);
+    // Move label to the end of the line
+    row.appendChild(row.querySelector('label'));
+  })();
+</script>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,3 +1,4 @@
 en:
   mail_subject_reaction_added: "%{reactor} reacted to your post"
   mail_body_reaction_added_intro: "%{reactor} reacted to your post."
+  label_reaction_notification: "Receive email notifications for reactions"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,3 +1,4 @@
 ja:
   mail_subject_reaction_added: "%{reactor} さんがあなたの投稿にリアクションしました"
   mail_body_reaction_added_intro: "%{reactor} さんがあなたの投稿にリアクションしました。"
+  label_reaction_notification: "リアクション通知をメールで受け取る"

--- a/init.rb
+++ b/init.rb
@@ -1,4 +1,6 @@
 require_relative 'lib/redmine_reaction_notifier/reaction_patch'
+require_relative 'lib/redmine_reaction_notifier/hooks'
+require_relative 'lib/redmine_reaction_notifier/user_preference_patch'
 
 Redmine::Plugin.register :redmine_reaction_notifier do
   name 'Redmine Reaction Notifier'
@@ -13,5 +15,8 @@ end
 Rails.configuration.after_initialize do
   unless Reaction.included_modules.include?(RedmineReactionNotifier::ReactionPatch)
     Reaction.include(RedmineReactionNotifier::ReactionPatch)
+  end
+  unless UserPreference.included_modules.include?(RedmineReactionNotifier::UserPreferencePatch)
+    UserPreference.include(RedmineReactionNotifier::UserPreferencePatch)
   end
 end

--- a/lib/redmine_reaction_notifier/hooks.rb
+++ b/lib/redmine_reaction_notifier/hooks.rb
@@ -1,0 +1,5 @@
+module RedmineReactionNotifier
+  class Hooks < Redmine::Hook::ViewListener
+    render_on :view_my_account_preferences, partial: 'hooks/my_account_preferences'
+  end
+end

--- a/lib/redmine_reaction_notifier/reaction_patch.rb
+++ b/lib/redmine_reaction_notifier/reaction_patch.rb
@@ -24,6 +24,7 @@ module RedmineReactionNotifier
       return if author == user
       return unless author.active?
       return if author.mail.blank?
+      return unless author.pref.reaction_notification
 
       ReactionNotifierMailer.reaction_added(User.current, self).deliver_later
     rescue StandardError => e

--- a/lib/redmine_reaction_notifier/user_preference_patch.rb
+++ b/lib/redmine_reaction_notifier/user_preference_patch.rb
@@ -1,0 +1,17 @@
+module RedmineReactionNotifier
+  module UserPreferencePatch
+    def self.included(base)
+      base.safe_attributes('reaction_notification')
+    end
+
+    # Default is enabled when no preference exists.
+    def reaction_notification
+      return false if self[:reaction_notification] == false
+      true
+    end
+
+    def reaction_notification=(value)
+      self[:reaction_notification] = ActiveModel::Type::Boolean.new.cast(value)
+    end
+  end
+end

--- a/test/mailers/reaction_notifier_mailer_test.rb
+++ b/test/mailers/reaction_notifier_mailer_test.rb
@@ -98,6 +98,44 @@ class ReactionNotifierMailerTest < ActionMailer::TestCase
     author.update_column(:status, User::STATUS_ACTIVE)
   end
 
+  test 'notify_reaction_added does not enqueue mail when author disabled notifications' do
+    reactor = users(:users_002)
+    author  = users(:users_003)
+    issue   = issues(:issues_001)
+    issue.update_column(:author_id, author.id)
+
+    # Disable notification
+    author.pref[:reaction_notification] = '0'
+    author.pref.save
+
+    reaction = build_reaction(reactor, issue)
+    assert_enqueued_emails 0 do
+      reaction.send(:notify_reaction_added)
+    end
+  ensure
+    # Reset to default (enabled)
+    author.pref.others.delete(:reaction_notification)
+    author.pref.others.delete('reaction_notification')
+    author.pref.save
+  end
+
+  test 'notify_reaction_added enqueues mail when author notification preference is not set (default)' do
+    reactor = users(:users_002)
+    author  = users(:users_003)
+    issue   = issues(:issues_001)
+    issue.update_column(:author_id, author.id)
+
+    # Ensure default (enabled) by removing any existing preference
+    author.pref.others.delete(:reaction_notification)
+    author.pref.others.delete('reaction_notification')
+    author.pref.save
+
+    reaction = build_reaction(reactor, issue)
+    assert_enqueued_emails 1 do
+      reaction.send(:notify_reaction_added)
+    end
+  end
+
   private
 
   # Build a Reaction-like object without touching the database.


### PR DESCRIPTION
This pull request adds a user preference that allows users to enable or disable email notifications for reactions to their posts. By default, notifications are enabled, and the preference is managed using Redmine's built-in `UserPreference` model without requiring any database schema changes. The implementation includes UI updates, localization, backend logic, and tests to ensure the feature works as expected.

**User Preference Feature:**

* Users can now enable or disable reaction notification emails via a new checkbox in their account preferences (`My account > Preferences`). This is implemented using the `UserPreference` model, with no database migrations required. The preference defaults to enabled. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R16-R18) [[2]](diffhunk://#diff-783cecde03b5bb45e473d383f369add5e36503746144ea1ffd270f14d13eea68R1-R17)
* The new preference field is added to the account preferences UI.
* The label for the new preference is localized in both English and Japanese. [[1]](diffhunk://#diff-44438ce218f5287c58d0017f965d888715635d94280669896f75841fbd7b4cd7R4) [[2]](diffhunk://#diff-b85e8d609d1ca8ea9aef96cf26c7011d39b5dd2e7de34dd4c52d931979917508R4)

**Backend Logic & Integration:**

* Reaction notification emails are only sent if the recipient has the reaction notification preference enabled.
* The `after_commit` callback for sending notifications is restricted to only trigger on reaction creation, preventing duplicate notifications on updates.
* The plugin initialization now includes the new user preference patch and the view hook for rendering the preference field. [[1]](diffhunk://#diff-4afdb3c3c34a069c37756ebaee5883f21565d29c7730ba4565b88aa809d226ccR2-R3) [[2]](diffhunk://#diff-4afdb3c3c34a069c37756ebaee5883f21565d29c7730ba4565b88aa809d226ccR19-R21)
* A new hook is added to render the partial for the preference field in the appropriate place in the account preferences view.

**Testing:**

* New tests verify that reaction notification emails are not sent when the user has disabled notifications and are sent when the preference is unset (default enabled).